### PR TITLE
Travis slack integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
  # - rbx-2
 # uncomment and edit the following line if your project needs to run something other than `rake`:
 script: bundle exec rspec
+
+notifications:
+  slack: thefirehoseproject:83Ltkj45Qz4MWJjNQvjGTqXn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
- - 2.3.1
- # commenting out the following two version of ruby to save travis build time
- # - jruby
- # - rbx-2
-# uncomment and edit the following line if your project needs to run something other than `rake`:
+- 2.3.1
 script: bundle exec rspec
-
 notifications:
-  slack: thefirehoseproject:83Ltkj45Qz4MWJjNQvjGTqXn
+  slack:
+    secure: ccHX7Fh9akhQ3kj51ftvz5KvdGTXf25GL5BfhdKWtbXanJuxWAXdeDFJy9MWnLWoK/hfBpD8FZZKaqKFIwKzXe4MqBa6SC3bN74aKrkx4sa4jMQ+TFPr3EjctGxLQ0gYfWGxd5ztYnQRQ9i7G0Dd9du8g9yKQ5wddHGd0nXHVho8QplVBpFaMTtsX87lQjniqG6b7YboyFwOk80ovPlRg2huXpY/93rDPnZ8rlf1zqpxW9UmMsUnPIVf+q0pV2dUDz/B7CvyjaA8dapdnEoruyFX8yhN/WgwqKon/PMq8y950CTSEBhqo8MfQBLj4vpyGincQxGuLFqHIpRYcUP69BLn1XUo45NTJm10Yca8n4mjY8mZ9+WUMRtcAXcYKIYul0sVlY5O9ux7GGMhzwTn8Y7LS4+6FVHlyo8qqxR7oFi9DHCBEmOu/2FKcq1ZcoiGRBecglRMXWNN2bLvGjw4alCetQH2Nk+SZL41IWeEnAhQRmJzrZy8MXAhsKNxbXcNgkUjp3kcnbz4y8g49BWgaPxpmPc2Ki0uHazK0hdDih3bTfScbEvbc+LPY0QfvN9ipF6dVAk98CNmeLSlEw0Wu//RJ03BPC8eLqxiKryXHpx5Ptfg+bV21AvC5hKC/2jPykEPew8wvOMeJxSbcDhKA73o8PcfXJbAG4x3DwObiB0=


### PR DESCRIPTION
To add in travis notifications to slack, I had to adjust the travis.yml file.

The instructions I followed are here:  https://thefirehoseproject.slack.com/services/B4N9APL9Y#service_setup

I also encrypted our key before adding it to the yml file (again, following the instructions in the above link).