### PR TITLE
Vertical obstruction logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ AllCops:
   DisplayStyleGuide: true
 
 Metrics/BlockLength:
-  Max: 29
+  Max: 50
   Exclude:
     - 'spec/controllers/**/*'
     - 'spec/routing/**/*'

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -52,16 +52,15 @@ class Piece < ApplicationRecord
     false
   end
 
-  def obstructed_vertically?(current_y:, target_y:)
-    # Initialize current_y to piece's starting 'y' position, then increment or decrement it
+  def obstructed_vertically?(to_y:)
     current_y = y_position
-    if current_y < target_y
-      while current_y < target_y
+    if current_y < to_y
+      while current_y < to_y
         current_y += 1
         return true if Piece.where(y_position: current_y, active: true).exists?
       end
     else
-      while current_y > target_y
+      while current_y > to_y
         current_y -= 1
         return true if Piece.where(y_position: current_y, active: true).exists?
       end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -51,4 +51,22 @@ class Piece < ApplicationRecord
     end
     false
   end
+
+  def obstructed_vertically?(current_y, target_y)
+    # Initialize current_y to piece's starting 'y' position, then increment or decrement it
+    current_y = y_position
+    target_y = gets
+
+    # The 'target' y_position is 'up' (i.e, in a HIGHER row of) the board
+    while current_y < target_y
+      current_y += 1
+      return true if Piece.where(y_position: current_y, active: true).exists?
+    end
+
+    # The 'target' y_position is 'down' (i.e, in a LOWER row of) the board
+    while current_y > target_y
+      current_y -= 1
+      return true if Piece.where(y_position: current_y, active: true).exists?
+    end
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -52,21 +52,20 @@ class Piece < ApplicationRecord
     false
   end
 
-  def obstructed_vertically?(current_y, target_y)
+  def obstructed_vertically?(current_y:, target_y:)
     # Initialize current_y to piece's starting 'y' position, then increment or decrement it
     current_y = y_position
-    target_y = gets
-
-    # The 'target' y_position is 'up' (i.e, in a HIGHER row of) the board
-    while current_y < target_y
-      current_y += 1
-      return true if Piece.where(y_position: current_y, active: true).exists?
+    if current_y < target_y
+      while current_y < target_y
+        current_y += 1
+        return true if Piece.where(y_position: current_y, active: true).exists?
+      end
+    else
+      while current_y > target_y
+        current_y -= 1
+        return true if Piece.where(y_position: current_y, active: true).exists?
+      end
     end
-
-    # The 'target' y_position is 'down' (i.e, in a LOWER row of) the board
-    while current_y > target_y
-      current_y -= 1
-      return true if Piece.where(y_position: current_y, active: true).exists?
-    end
+    false
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -34,15 +34,26 @@ RSpec.describe Piece, type: :model do
 
   # Vertical obstructions:
   describe '#obstructed_vertically?' do
-    it 'returns true if the move is obstructed vertically' do
+    it 'returns true if the move is obstructed vertically going up the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
-      _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4)
-      expect(moving_piece.obstructed_vertically?(from_x: 1, from_y: 3, to_x: 1, to_y: 7)).to eq(true)
+      _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4) # Use _ for unused variable
+      expect(moving_piece.obstructed_vertically?(current_y: 3, target_y: 7)).to eq(true)
     end
 
-    it 'returns false if the move is not obstructed vertically' do
+    it 'returns true if the move is obstructed vertically going down the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 6)
+      _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4) # Use _ for unused variable
+      expect(moving_piece.obstructed_vertically?(current_y: 6, target_y: 2)).to eq(true)
+    end
+
+    it 'returns false if the move is not obstructed vertically going up the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
-      expect(moving_piece.obstructed_vertically?(from_x: 1, from_y: 3, to_x: 1, to_y: 7)).to eq(false)
+      expect(moving_piece.obstructed_vertically?(current_y: 3, target_y: 7)).to eq(false)
+    end
+
+    it 'returns false if the move is not obstructed vertically going down the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 8)
+      expect(moving_piece.obstructed_vertically?(current_y: 8, target_y: 2)).to eq(false)
     end
   end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe Piece, type: :model do
       expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 8, to_y: 8)).to eq(false)
     end
   end
+
+  # Vertical obstructions:
+  describe '#obstructed_vertically?' do
+    it 'returns true if the move is obstructed vertically' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4)
+      expect(moving_piece.obstructed_vertically?(from_x: 1, from_y: 3, to_x: 1, to_y: 7)).to eq(true)
+    end
+
+    it 'returns false if the move is not obstructed vertically' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.obstructed_vertically?(from_x: 1, from_y: 3, to_x: 1, to_y: 7)).to eq(false)
+    end
+  end
 end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -37,23 +37,23 @@ RSpec.describe Piece, type: :model do
     it 'returns true if the move is obstructed vertically going up the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4) # Use _ for unused variable
-      expect(moving_piece.obstructed_vertically?(current_y: 3, target_y: 7)).to eq(true)
+      expect(moving_piece.obstructed_vertically?(to_y: 7)).to eq(true)
     end
 
     it 'returns true if the move is obstructed vertically going down the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 6)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 4) # Use _ for unused variable
-      expect(moving_piece.obstructed_vertically?(current_y: 6, target_y: 2)).to eq(true)
+      expect(moving_piece.obstructed_vertically?(to_y: 2)).to eq(true)
     end
 
     it 'returns false if the move is not obstructed vertically going up the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
-      expect(moving_piece.obstructed_vertically?(current_y: 3, target_y: 7)).to eq(false)
+      expect(moving_piece.obstructed_vertically?(to_y: 7)).to eq(false)
     end
 
     it 'returns false if the move is not obstructed vertically going down the board' do
       moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 8)
-      expect(moving_piece.obstructed_vertically?(current_y: 8, target_y: 2)).to eq(false)
+      expect(moving_piece.obstructed_vertically?(to_y: 2)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
This pull request adds logic to check whether a piece is obstructed (blocked) from moving vertically (i.e, "up and down" the board).

The method `obstructed_vertically?` will return `true` if the move is obstructed and will return `false` if it is not.