### PR TITLE
Updated obstructed_diagonally? logic

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,13 +9,13 @@ class Piece < ApplicationRecord
   validates :y_position, presence: true
   validates :game_id, presence: true
 
-  def obstructed_diagonally?(from_x:, from_y:, to_x:, to_y:)
+  def obstructed_diagonally?(to_x:, to_y:)
     # Current_x and current_y are used as incrementer variables
-    current_x = from_x
-    current_y = from_y
+    current_x = x_position
+    current_y = y_position
     #
     # Use this IF when destination is up-right
-    if to_x > from_x && to_y > from_y
+    if to_x > x_position && to_y > y_position
       until current_x == to_x && current_y == to_y
         current_x += 1
         current_y += 1
@@ -24,7 +24,7 @@ class Piece < ApplicationRecord
     end
     #
     # Use this IF when destination is down-left
-    if to_x < from_x && to_y < from_y
+    if to_x < x_position && to_y < y_position
       until current_x == to_x && current_y == to_y
         current_x -= 1
         current_y -= 1
@@ -33,7 +33,7 @@ class Piece < ApplicationRecord
     end
     #
     # Use this IF when destination is up-left
-    if to_x < from_x && to_y > from_y
+    if to_x < x_position && to_y > y_position
       until current_y == to_y && current_x == to_x
         current_x -= 1 if current_x != to_x
         current_y += 1 if current_y != to_y
@@ -42,7 +42,7 @@ class Piece < ApplicationRecord
     end
     #
     # Use this IF when destination is down-right
-    if to_x > from_x && to_y < from_y
+    if to_x > x_position && to_y < y_position
       until current_y == to_y && current_x == to_x
         current_x += 1 if current_x != to_x
         current_y -= 1 if current_y != to_y

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -5,30 +5,30 @@ RSpec.describe Piece, type: :model do
     it 'returns true if the move is obstructed in the up-right direction' do
       moving_piece = FactoryGirl.create(:piece, x_position: 4, y_position: 4)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 6, y_position: 6)
-      expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 8, to_y: 8)).to eq(true)
+      expect(moving_piece.obstructed_diagonally?(to_x: 8, to_y: 8)).to eq(true)
     end
 
     it 'returns true if the move is obstructed in the down-left direction' do
       moving_piece = FactoryGirl.create(:piece, x_position: 4, y_position: 4)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 2, y_position: 2)
-      expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 1, to_y: 1)).to eq(true)
+      expect(moving_piece.obstructed_diagonally?(to_x: 1, to_y: 1)).to eq(true)
     end
 
     it 'returns true if the move is obstructed in the up-left direction' do
       moving_piece = FactoryGirl.create(:piece, x_position: 4, y_position: 4)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 2, y_position: 6)
-      expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 1, to_y: 7)).to eq(true)
+      expect(moving_piece.obstructed_diagonally?(to_x: 1, to_y: 7)).to eq(true)
     end
 
     it 'returns true if the move is obstructed in the down-right direction' do
       moving_piece = FactoryGirl.create(:piece, x_position: 4, y_position: 4)
       _blocking_piece = FactoryGirl.create(:piece, x_position: 6, y_position: 2)
-      expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 7, to_y: 1)).to eq(true)
+      expect(moving_piece.obstructed_diagonally?(to_x: 7, to_y: 1)).to eq(true)
     end
 
     it 'returns false if the move is not obstructed' do
       moving_piece = FactoryGirl.create(:piece, x_position: 4, y_position: 4)
-      expect(moving_piece.obstructed_diagonally?(from_x: 4, from_y: 4, to_x: 8, to_y: 8)).to eq(false)
+      expect(moving_piece.obstructed_diagonally?(to_x: 8, to_y: 8)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Now uses implicit x_position and y_position values pulled from instance of `piece` object that the method is being called on.