### PR TITLE
Updated Queen factory and move validation method

### DIFF
--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,10 +1,10 @@
 class Queen < Piece
-  def valid_queen_move?(to_x:, to_y:)
-    diag_vert = (to_y - y_position).abs
-    diag_horz = (to_x - x_position).abs
-    diag_delta = diag_vert - diag_horz
-    return true if diag_horz != 0 && to_y == y_position
-    return true if diag_vert != 0 && to_x == x_position
+  def valid_move?(to_x:, to_y:)
+    dist_vert = (to_y - y_position).abs
+    dist_horz = (to_x - x_position).abs
+    diag_delta = dist_vert - dist_horz
+    return true if dist_horz != 0 && to_y == y_position
+    return true if dist_vert != 0 && to_x == x_position
     return true if diag_delta.zero?
     false
   end

--- a/spec/factories/pieces.rb
+++ b/spec/factories/pieces.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
   factory :queen do
     color 'white'
     active true
-    x_position 1
-    y_position 1
+    x_position 4
+    y_position 4
     type 'Queen'
     association :game
   end

--- a/spec/models/queen_spec.rb
+++ b/spec/models/queen_spec.rb
@@ -8,50 +8,51 @@ RSpec.describe Queen, type: :model do
     end
   end
 
-  describe '#valid_queen_move?' do
+  describe '#valid_move?' do
+    # Initial Queen position from factory is (4,4)
     it 'returns true if the move is diagonal up-right from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 7, to_y: 7)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 7, to_y: 7)).to eq(true)
     end
 
     it 'returns true if the move is diagonal down-right from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 7, to_y: 1)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 7, to_y: 1)).to eq(true)
     end
 
     it 'returns true if the move is diagonal up-left from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 2, to_y: 6)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 2, to_y: 6)).to eq(true)
     end
 
     it 'returns true if the move is diagonal down-left from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 2, to_y: 2)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 2, to_y: 2)).to eq(true)
     end
 
     it 'returns true if the move is vertical up from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 4, to_y: 7)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 4, to_y: 7)).to eq(true)
     end
 
     it 'returns true if the move is vertical down from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 4, to_y: 1)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 4, to_y: 1)).to eq(true)
     end
 
     it 'returns true if the move is horizontal left from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 1, to_y: 4)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 1, to_y: 4)).to eq(true)
     end
 
     it 'returns true if the move is horizontal right from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 7, to_y: 4)).to eq(true)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 7, to_y: 4)).to eq(true)
     end
 
     it 'returns false if the move is not horiz, vert, or diag from the queen' do
-      queen = FactoryGirl.create(:queen, x_position: 4, y_position: 4)
-      expect(queen.valid_queen_move?(to_x: 5, to_y: 7)).to eq(false)
+      queen = FactoryGirl.create(:queen)
+      expect(queen.valid_move?(to_x: 5, to_y: 7)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Changed queen factory coordinates to (4,4) to make tests a little cleaner.
Also changed the name of the move validation method from `valid_queen_move?` to  `valid_move?` in keeping with our discussions about inherited method flow-down.