### PR TITLE
Off board check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ AllCops:
   DisplayStyleGuide: true
 
 Metrics/BlockLength:
-  Max: 70
+  Max: 85
   Exclude:
     - 'spec/controllers/**/*'
     - 'spec/routing/**/*'

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -85,4 +85,11 @@ class Piece < ApplicationRecord
     end
     false
   end
+
+  def remains_on_board?(to_x:, to_y:)
+    if to_x >= 1 && to_x <= 8 && to_y >= 1 && to_y <= 8
+    else
+      false
+    end
+  end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -88,6 +88,7 @@ class Piece < ApplicationRecord
 
   def remains_on_board?(to_x:, to_y:)
     if to_x >= 1 && to_x <= 8 && to_y >= 1 && to_y <= 8
+      true
     else
       false
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -81,4 +81,27 @@ RSpec.describe Piece, type: :model do
       expect(moving_piece.obstructed_horizontally?(to_x: 2)).to eq(false)
     end
   end
+
+  # Off board check:
+  describe '#remains_on_board' do
+    it 'returns true if the move is to a square on the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.remains_on_board?(to_x: 7, to_y: 3)).to eq(true)
+    end
+
+    it 'returns false if the moving piece has an x_position off the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.remains_on_board?(to_x: 11, to_y: 3)).to eq(false)
+    end
+
+    it 'returns false if the moving piece has a y_position off the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.remains_on_board?(to_x: 1, to_y: -1)).to eq(false)
+    end
+
+    it 'returns false if the moving piece has an x_position and a y_position off the board' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.remains_on_board?(to_x: 0, to_y: 13)).to eq(false)
+    end    
+  end
 end


### PR DESCRIPTION
I believe this branch is ready to be merged. It adds a remains_on_board? method to ensure that the to_x and to_y coordinates remain within the 1 through 8 coordinates. The spec tests include one for true and three for false (just the to_x coordinate is off the board, just the to_y coordinate is off the board, and both the to_x and the to_y coordinates are off the board). If someone could look through it, I would appreciate it.