### PR TITLE
added test to ensure that the moving piece has left its original coordinates

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,20 +9,23 @@ class Piece < ApplicationRecord
   validates :y_position, presence: true
   validates :game_id, presence: true
 
-  # Moving piece logic
+  # Moving piece logic (possibly add pieces_turn to the end of the return true if statement)
   def move_tests(to_x:, to_y:)
     return true if valid_move?(to_x: to_x, to_y: to_y) &&
                    !obstructed_diagonally?(to_x: to_x, to_y: to_y) &&
                    !obstructed_horizontally?(to_x: to_x) &&
                    !obstructed_vertically?(to_y: to_y) &&
-                   remains_on_board?(to_x: to_x, to_y: to_y)
+                   remains_on_board?(to_x: to_x, to_y: to_y) &&
+                   did_it_move?(to_x: to_x, to_y: to_y)
     false
   end
 
-  ### NOTE: DOESN'T WORK FOR PIECE WITH TYPE ###
-  # Default move check to ensure that the piece moves
-  def valid_move?(to_x:, to_y:)
-    return true if to_x != x_position && to_y != y_position
+  def valid_move?
+    true
+  end
+
+  def did_it_move?(to_x:, to_y:)
+    return true if to_x != x_position || to_y != y_position
     false
   end
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -226,4 +226,27 @@ RSpec.describe Piece, type: :model do
       expect(moving_piece.pieces_turn?).to eq(false)
     end
   end
+
+  # Testing of did_it_move? method for piece
+  describe 'did_it_move?' do
+    it 'returns true if moved piece has a different y coordinate than when first moved' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.did_it_move?(to_x: 1, to_y: 4)).to eq(true)
+    end
+
+    it 'returns true if moved piece has a different x coordinate than when first moved' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.did_it_move?(to_x: 2, to_y: 3)).to eq(true)
+    end
+
+    it 'returns true if moved piece has different x & y coordinates than when first moved' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.did_it_move?(to_x: 3, to_y: 5)).to eq(true)
+    end
+
+    it 'returns false if moved piece has the same coordinates as when first moved' do
+      moving_piece = FactoryGirl.create(:piece, x_position: 1, y_position: 3)
+      expect(moving_piece.did_it_move?(to_x: 1, to_y: 3)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This branch is ready for a review.

A couple of notes:
 - This branch was initiated by the Trello card "Implement Touch Rule" but the description in the card was merely a test to make sure that a piece, once "touched", actually moved. This is an essential test to ensure that a "touched" piece that doesn't actually leave it's home cell, doesn't get counted as a turn.
 -  According to wikipedia, “The touch-move rule in chess specifies that, if a player deliberately touches a piece on the board when it is their turn to move, then the player must move or capture that piece if it is legal to do so. If it is the player’s piece that was touched, it must be moved if it has a legal move.”
 - As you can see from the above definition, the touch rule will take quite a bit of additional logic: logic to lock the touched piece to the user's turn if it doesn't actually move onced touched, and logic to check to make sure there are available legal moves to be made.
 - I will make a new Trello card for the touch rule but I'm throwing it down at the bottom with the rest of the edge cases.