### PR TITLE
Added logic and tests to advance game to the next turn

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -39,13 +39,16 @@ class PiecesController < ApplicationController
   # PATCH/PUT /pieces/1.json
   def update
     @piece = Piece.find(params[:id])
+    @pieces_game = Game.find(@piece.game_id)
     to_y = params[:piece][:y_position].to_i
     to_x = params[:piece][:x_position].to_i
 
     # The update method will change the x_position and y_position of a piece in the database.
     # This checks if the move is valid by using the #move_tests method in the model
+    return if !@piece.move_tests(to_x: to_x, to_y: to_y)
+    @piece.update(piece_params)
+    @pieces_game.next_turn
 
-    @piece.update(piece_params) if @piece.move_tests(to_x: to_x, to_y: to_y)
     ### Below is the scaffolding that we'll need to fool with to make the UI go ###
     # respond_to do |format|
     #   format.html { redirect_to @piece, notice: 'Piece was successfully updated.' }

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -45,7 +45,7 @@ class PiecesController < ApplicationController
 
     # The update method will change the x_position and y_position of a piece in the database.
     # This checks if the move is valid by using the #move_tests method in the model
-    return if !@piece.move_tests(to_x: to_x, to_y: to_y)
+    return unless @piece.move_tests(to_x: to_x, to_y: to_y)
     @piece.update(piece_params)
     @pieces_game.next_turn
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -126,10 +126,29 @@ RSpec.describe PiecesController, type: :controller do
         piece.reload
         expect(piece.x_position).to eq(4)
       end
+
+      it 'advances the game to the next turn' do
+        piece = FactoryGirl.create(:queen, x_position: 2, y_position: 2, game_id: game2.id)
+          put :update, params:
+            {
+              id: piece.to_param, piece:
+                {
+                  color: 'white',
+                  active: true,
+                  x_position: 4,
+                  y_position: 4,
+                  # # Type needs to be implemented when first piece is created:
+                  # type: 'rook',
+                  game_id: game2.id
+                }
+            }, session: valid_session
+        game2.reload
+        expect(game2.current_color).to eq('black')
+      end
     end
 
     context 'with invalid params' do
-      it 'updates the requested piece' do
+      it 'does not update the requested piece' do
         piece = FactoryGirl.create(:queen, x_position: 2, y_position: 2)
         put :update, params:
             {
@@ -146,6 +165,25 @@ RSpec.describe PiecesController, type: :controller do
             }, session: valid_session
         piece.reload
         expect(piece.x_position).to eq(2)
+      end
+
+      it 'does not advance the game to the next turn' do
+        piece = FactoryGirl.create(:queen, x_position: 2, y_position: 2, game_id: game2.id)
+          put :update, params:
+            {
+              id: piece.to_param, piece:
+                {
+                  color: 'white',
+                  active: true,
+                  x_position: 9,
+                  y_position: 13,
+                  # # Type needs to be implemented when first piece is created:
+                  # type: 'rook',
+                  game_id: game2.id
+                }
+            }, session: valid_session
+        game2.reload
+        expect(game2.current_color).to eq('white')
       end
     end
   end


### PR DESCRIPTION
This branch makes the game advance to the next turn by having the `pieces_controller` call the `next_turn` method on the game that the piece belongs to upon a successful move. This means that the game that a moved piece belongs to has its `current_color` swapped with its `resting_color`, but it only happens when a move is successful, i.e. all the criteria for a valid move are met.