### PR TITLE
Prevent pawn from capturing piece straight ahead of it.

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -21,7 +21,7 @@ class Piece < ApplicationRecord
     false
   end
 
-  def valid_move?
+  def valid_move?(*)
     true
   end
 
@@ -94,7 +94,7 @@ class Piece < ApplicationRecord
     return 'success' if target_piece.nil?
 
     # Valid move with enemy piece captured at destination
-    if !target_piece.nil? && !target_piece.pieces_turn?
+    if type != 'pawn' && !target_piece.nil? && !target_piece.pieces_turn?
       target_piece.update(active: false)
       return 'success'
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Piece, type: :model do
       FactoryGirl.create(:bishop, color: 'white')
       expect(white_queen.move_tests(to_x: 5, to_y: 5)).to eq(false)
     end
+
+    it 'returns false if a pawn tries to capture a piece one square in front of it' do
+      moving_piece = FactoryGirl.create(:piece, type: 'pawn', color: 'white', x_position: 4, y_position: 4)
+      FactoryGirl.create(:piece, color: 'black', x_position: 4, y_position: 5)
+      expect(moving_piece.move_tests(to_x: 4, to_y: 5)).to eq(false)
+    end
   end
 
   # Diagonal obstruction logic


### PR DESCRIPTION
Edited **piece_spec.rb** and **piece.rb** to ensure that a pawn can't capture piece straight in front of it.