### PR TITLE
Made pieces appear in top 2 and bottom 2 rows of board

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,8 +9,8 @@
 </div>
 <br />
 <table id="htmlboard">
-  <% x = 8 %>
-  <% y = 1 %>
+  <% y = 8 %>
+  <% x = 1 %>
   <% 8.times do %>
     <tr>
       <% 8.times do %>
@@ -19,10 +19,10 @@
             <%= render_piece(x, y) %>
           </div>
         </td>
-        <% y += 1 %>
+        <% x += 1 %>
       <% end %>
-    <% y = 1 %>
-    <% x -= 1 %>
+    <% x = 1 %>
+    <% y -= 1 %>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
Previously the **games/show.html.erb** file was initializing the board by placing pieces in the two far-left and two far-right columns of the board. Edited this file to make pieces appear in **top** two and **bottom** two rows of board.