### PR TITLE
Specified Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.3.1'
 
 gem 'rails', '~> 5.0.2'
 


### PR DESCRIPTION
Specifying the Ruby version in the Gemfile might help resolve the issue where the app works normally in development but crashes in production.

The Heroku logs indicate that the app is crashing on an `unexpected '.'` when it gets to the `&.` operators in the `games_helper.rb` file. The safety operator (`&.`) was introduced in Ruby 2.3, and the Heroku deployment defaults to Ruby 2.2.6 unless you specify otherwise.